### PR TITLE
fixed text overlap with whale in StartBlock

### DIFF
--- a/src/components/StartBlock.tsx
+++ b/src/components/StartBlock.tsx
@@ -37,7 +37,8 @@ const futureBox = classnames(
   flexDirection('md:flex-row', 'flex-col-reverse'),
   alignItems('items-center'),
   justifyContent('justify-end'),
-  space('md:space-x-4')
+  space('md:space-x-4'),
+  margin('mt-32', 'sm:mt-40', 'lg:mt-0')
 )
 const textBlock = classnames(
   display('flex'),


### PR DESCRIPTION
## What
* Moved text down a bit on >lg screen sizes to prevent text overlap with prism whale
##  Demo
[Top of Parallax on Fold](https://user-images.githubusercontent.com/26176104/173955499-2e67a8fa-e5f8-4e78-9577-5f8e2273d9b8.png)
[End of Parallax on Fold](https://user-images.githubusercontent.com/26176104/173955560-78c23a6a-fc31-4f82-ba84-49f8444ae6c3.png)