### PR TITLE
fixed PrivacyWorld text not wrapping properly on smaller phone screens

### DIFF
--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -48,7 +48,7 @@ const largeStrokeTextAccent = classnames(
   textAlign('text-justify'),
   textTransform('uppercase'),
   fontFamily('font-primary'),
-  fontSize('text-5xl', 'md:text-8xl'),
+  fontSize('text-3xl', 'tiny:text-5xl', 'md:!text-7xl', 'lg:!text-8xl'),
   lineHeight('leading-10', 'md:leading-12')
 )
 export function LargeStrokeText({

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,7 +52,7 @@ module.exports = {
         15: '10.438rem',
       },
       screens: {
-        tiny: '22.5rem',
+        tiny: '22.75rem',
         tablet: '31.25rem',
         md: '37.5rem',
         sm: '40rem',


### PR DESCRIPTION
## What
* Fixed PrivacyWorld text wrapping mid-word on screensizes smaller than 364px
## Demo
[New text wrapping here](https://drive.google.com/file/d/1lkWTtDbEXu-XeXz4BnqOWOA4ZALK1U1X/view?usp=sharing)
