### PR TITLE
Fix sizing of Footer logo

### DIFF
--- a/src/icons/LogoText.tsx
+++ b/src/icons/LogoText.tsx
@@ -8,7 +8,11 @@ import classnames, {
 const pathFill = fill('fill-primary')
 const svgWrapper = (large?: boolean) =>
   classnames(
-    width(large ? 'w-60' : 'w-16'),
+    width(
+      large
+        ? { 'w-32': true, 'sm:w-60': true }
+        : { 'w-14': true, 'sm:w-20': true }
+    ),
     height('h-full'),
     dropShadow('drop-shadow-primary')
   )


### PR DESCRIPTION
- updated `FooterLogo` sizing to match iPhone 5/5s/SE/SE 2 sizes

![image](https://user-images.githubusercontent.com/5114069/185987434-96cc522b-0137-4450-885c-64dd3482f5eb.png)
![image](https://user-images.githubusercontent.com/5114069/185987461-570a7f2d-e962-4b6d-a797-6b2339bfed1d.png)
